### PR TITLE
Fixed Yosys select command syntax to support newer Yosys versions.

### DIFF
--- a/v2x/yosys/run.py
+++ b/v2x/yosys/run.py
@@ -273,7 +273,7 @@ def get_combinational_sinks(infiles, module, innet):
     innet: Name of input net to find sinks of
     """
     return do_select(
-        infiles, module, "{} %co* o:* %i {} %d".format(innet, innet)
+        infiles, module, "={} %co* =o:* %i ={} %d".format(innet, innet)
     )
 
 
@@ -287,7 +287,7 @@ def list_clocks(infiles, module):
     """
     return do_select(
         infiles, module,
-        "c:* %x:+[CLK]:+[clk]:+[clock]:+[CLOCK] c:* %d x:* %i"
+        "=c:* %x:+[CLK]:+[clk]:+[clock]:+[CLOCK] =c:* %d =x:* %i"
     )
 
 
@@ -302,7 +302,7 @@ def get_clock_assoc_signals(infiles, module, clk):
     """
     return do_select(
         infiles, module,
-        "select -list {} %a %co* %x i:* o:* %u %i a:ASSOC_CLOCK={} %u {} %d".
+        "select -list ={} %a %co* %x =i:* =o:* %u %i =a:ASSOC_CLOCK={} %u ={} %d".
         format(clk, clk, clk)
     )
 
@@ -327,7 +327,7 @@ def get_related_output_for_input(infiles, module, signal):
     clk: Name of clock to find associated signals
     """
     return do_select(
-        infiles, module, "select -list w:*{} %a %co* o:* %i".format(signal)
+        infiles, module, "select -list =w:*{} %a %co* =o:* %i".format(signal)
     )
 
 
@@ -343,6 +343,6 @@ def get_related_inputs_for_input(infiles, module, signal):
     return [
         x for x in do_select(
             infiles, module,
-            "select -list w:*{} %a %co* %x i:* %i".format(signal)
+            "select -list =w:*{} %a %co* %x =i:* %i".format(signal)
         ) if x != signal
     ]


### PR DESCRIPTION
This PR fixes inference of cell signal relation. This has to do with a new syntax of select patterns for blackbox/whitebox cells that was added to Yosys in:

```
commit eaa5a3e786e7ebc5ad25ebd08e7e42f5a5337b5c
Author: Eddie Hung <eddie@fpgeh.com>
Date:   Wed Apr 22 10:15:56 2020 -0700

    select: do not select black/white boxes by default, '=' prefix to do so
```

Once that is merged V2X **will not work with any Yosys version from before that commit!**